### PR TITLE
feat: build for apple intel

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,11 +9,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         
-      - name: Build
+      - name: Install Cross-compilation requirements
+        run: rustup target add x86_64-apple-darwin
+
+      - name: Build Apple Silicon
         run: cargo build --verbose --release
       
-      - name: Upload Artifacts
+      - name: Build Apple Intel
+        run: cargo build --verbose --release --target x86_64-apple-darwin
+      
+      - name: Upload Apple Silicon Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: hplc-rs
+          name: hplc-rs-apple-silicon
           path: ./target/release/HPLC-RS
+      
+      - name: Upload Apple Intel Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: hplc-rs-apple-intel
+          path: ./target/x86_64-apple-darwin/release/HPLC-RS

--- a/README.md
+++ b/README.md
@@ -224,7 +224,8 @@ It has not been tested on Windows.
 Pre-built binaries are offered for the following systems
 * x86_64-linux
 * x86_64-windows
-* aarch64-darwin
+* aarch64-darwin (Apple Silicon)
+* x86_64-darwin (Apple Intel)
 
 More details in [Installation](#installation)
 Other systems may need to compile from source according to [Compilation](#compilation)


### PR DESCRIPTION
Some researchers still have Apple Intel systems in their departments which may require them to use x86_64-apple-darwin build of HPLC-RS